### PR TITLE
Add custom migration template to specify id and timestamp defaults

### DIFF
--- a/priv/repo/migrations/20201104222052_enable_pgcrypto.exs
+++ b/priv/repo/migrations/20201104222052_enable_pgcrypto.exs
@@ -1,0 +1,11 @@
+defmodule PhoenixStarter.Repo.Migrations.EnablePgcrypto do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+  end
+
+  def down do
+    execute("DROP EXTENSION IF EXISTS pgcrypto")
+  end
+end

--- a/priv/templates/phx.gen.schema/migration.exs
+++ b/priv/templates/phx.gen.schema/migration.exs
@@ -1,0 +1,15 @@
+defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.table) %> do
+  use <%= inspect schema.migration_module %>
+
+  def change do
+    create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %>) do
+<%= if schema.binary_id do %>      add :id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()")
+<% end %><%= for {k, v} <- schema.attrs do %>      add <%= inspect k %>, <%= inspect v %><%= schema.migration_defaults[k] %>
+<% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= inspect(i) %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>)
+<% end %>
+      timestamps default: fragment("now()")
+    end
+<%= if Enum.any?(schema.indexes) do %><%= for index <- schema.indexes do %>
+    <%= index %><% end %>
+<% end %>  end
+end


### PR DESCRIPTION
This lets us specify defaults in the database for the id (pk) and
timestamp columns. This makes database administration outside of
Elixir/Ecto easier, since these fields will have auto defaults now.

This template is used with `mix phx.gen.schema`, so this will only help
if you use one of the Phx generators.
