### PR TITLE
Remove unused Tailwind CSS configuration

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -13,14 +13,7 @@ module.exports = {
     "./js/**/*.tsx",
   ],
   theme: {
-    extend: {
-      backgroundOpacity: {
-        40: "0.4",
-      },
-      zIndex: {
-        1: 1,
-      },
-    },
+    extend: {},
   },
   variants: {},
   plugins: [],


### PR DESCRIPTION
The utility classes that this configuration generated are no longer in use anywhere in the code base.